### PR TITLE
Fixing orientation deprecated method in iOS 16.

### DIFF
--- a/src/ios/CDVOrientation.m
+++ b/src/ios/CDVOrientation.m
@@ -80,7 +80,15 @@
             }
             if (value != nil) {
                 _isLocked = true;
-                [[UIDevice currentDevice] setValue:value forKey:@"orientation"];
+                if (@available(iOS 16.0, *)) {
+                    if ([self.viewController respondsToSelector:@selector(setNeedsUpdateOfSupportedInterfaceOrientations)]) {
+                        [self.viewController setNeedsUpdateOfSupportedInterfaceOrientations];
+                    } else {
+                        [[UIDevice currentDevice] setValue:value forKey:@"orientation"];
+                    }
+                } else {
+                    [[UIDevice currentDevice] setValue:value forKey:@"orientation"];
+                }
             } else {
                 _isLocked = false;
             }


### PR DESCRIPTION
Fixed : [JIR-8616](https://healthrecoverysolutions.atlassian.net/browse/JIR-8616) [PCM - iOS 16.0 only] After playing education video once, the phone orientation turns to 'Landscape' mode until the app is killed

- Added new method for handling orientation update in iOS 16. 
- Minimum Xcode 14 would be needed to build this. 